### PR TITLE
Allow seamless role list-interaction list switching

### DIFF
--- a/concert_qt_teleop/src/concert_qt_teleop/teleop.py
+++ b/concert_qt_teleop/src/concert_qt_teleop/teleop.py
@@ -69,12 +69,12 @@ class Teleop(Plugin):
 
         self._widget.release_teleop_btn.setEnabled(False)
         self.teleop_app_info = TeleopManager(
-            image_received_slot=self._widget.camera_view.on_compressed_image_received
+            image_received_slot=self._widget.camera_view.on_compressed_image_received,
+            event_callback=self._refresh_robot_list,
+            capture_event_callback=self._capture_event_callback,
+            release_event_callback=self._release_event_callback,
+            error_event_callback=self._error_event_callback,
         )
-        self.teleop_app_info._reg_event_callback(self._refresh_robot_list)
-        self.teleop_app_info._reg_capture_event_callback(self._capture_event_callback)
-        self.teleop_app_info._reg_release_event_callback(self._release_event_callback)
-        self.teleop_app_info._reg_error_event_callback(self._error_event_callback)
 
         self.robot_item_list = {}
         self.current_robot = None

--- a/concert_qt_teleop/src/concert_qt_teleop/teleop_app_info.py
+++ b/concert_qt_teleop/src/concert_qt_teleop/teleop_app_info.py
@@ -22,14 +22,20 @@ import threading
 
 
 class TeleopManager(object):
-    def __init__(self, image_received_slot):
+    def __init__(self,
+                 image_received_slot,
+                 event_callback,
+                 capture_event_callback,
+                 release_event_callback,
+                 error_event_callback
+                 ):
         self._lock = threading.Lock()
         self.teleop_interface = None
         self._image_received_slot = image_received_slot
-        self._capture_event_callback = None
-        self._release_event_callback = None
-        self._error_event_callback = None
-        self._event_callback = None
+        self._capture_event_callback = capture_event_callback
+        self._release_event_callback = release_event_callback
+        self._error_event_callback = error_event_callback
+        self._event_callback = event_callback
         self.robot_list = {}
         self.pre_robot_list = {}
         self.service_pair_msg_q = []
@@ -178,15 +184,3 @@ class TeleopManager(object):
             if self.teleop_interface:
                 self.teleop_interface.shutdown()
                 self.teleop_interface = None
-
-    def _reg_event_callback(self, func):
-        self._event_callback = func
-
-    def _reg_error_event_callback(self, func):
-        self._error_event_callback = func
-
-    def _reg_capture_event_callback(self, func):
-        self._capture_event_callback = func
-
-    def _reg_release_event_callback(self, func):
-        self._release_event_callback = func

--- a/rocon_remocon/scripts/rocon_remocon_sub
+++ b/rocon_remocon/scripts/rocon_remocon_sub
@@ -30,7 +30,7 @@ interactions_chooser = None
 def signal_handler(signum, f):
     print "[sub] Interrupt"
     if signum == signal.SIGINT:
-        interactions_chooser._uninit_role_list()
+        interactions_chooser.shutdown()
         app.exit(0)
 
 ##############################################################################

--- a/rocon_remocon/src/rocon_remocon/interactions.py
+++ b/rocon_remocon/src/rocon_remocon/interactions.py
@@ -1,0 +1,72 @@
+#
+# License: BSD
+#   https://raw.github.com/robotics-in-concert/rocon_qt_gui/license/LICENSE
+#
+##############################################################################
+# Description
+##############################################################################
+
+"""
+.. module:: interactions
+   :platform: Unix
+   :synopsis: Representative class and methods for an *interaction*.
+
+
+This module defines a class and methods that represent the core of what
+an interaction is for a remocon.
+
+----
+
+"""
+##############################################################################
+# Imports
+##############################################################################
+
+import os
+import rocon_console.console as console
+#import rocon_interaction_msgs.msg as rocon_interaction_msgs
+import rocon_interactions
+from . import utils
+
+##############################################################################
+# Classes
+##############################################################################
+
+
+class Interaction(rocon_interactions.Interaction):
+    '''
+      This class defines an interaction for the rocon_remocon.
+      It does so by wrapping the base
+      rocon_interaction.Interaction class with a few extra
+      variables and methods.
+    '''
+    __slots__ = [
+        'launch_list',  # dictionary of launch information
+        'icon',
+        'index'
+    ]
+
+    def __init__(self, msg):
+        """
+          :param msg: underlying data structure with fields minimally filled via :func:`.load_msgs_from_yaml_resource`.
+          :type msg: rocon_interaction_msgs.Interaction_
+
+          .. include:: weblinks.rst
+        """
+        super(Interaction, self).__init__(msg)
+        self.launch_list = {}
+        self.index = None
+        icon_name = msg.icon.resource_name.split('/').pop()
+        if msg.icon.data:
+            icon = open(os.path.join(utils.get_icon_cache_home(), icon_name), 'w')
+            icon.write(msg.icon.data)
+            icon.close()
+        self.icon = icon_name
+
+    def __str__(self):
+        '''
+          Format the interaction into a human-readable string.
+        '''
+        s = rocon_interactions.Interaction.__str__(self)
+        s += console.cyan + "  Launch List" + console.reset + "  : " + console.yellow + "%s" % self.launch_list.keys() + console.reset + '\n'  # noqa
+        return s

--- a/rocon_remocon/src/rocon_remocon/interactions_chooser.py
+++ b/rocon_remocon/src/rocon_remocon/interactions_chooser.py
@@ -46,7 +46,6 @@ class QInteractionsChooser(QMainWindow):
         self.application = application
 
         super(QInteractionsChooser, self).__init__(parent)
-        self.initialised = False
 
         self.interactions_widget = QWidget()
         self.roles_widget = QWidget()
@@ -68,14 +67,14 @@ class QInteractionsChooser(QMainWindow):
 
         # role list widget
         self.roles_widget.role_list_widget.setIconSize(QSize(50, 50))
-        self.roles_widget.role_list_widget.itemDoubleClicked.connect(self._select_role_list)
-        self.roles_widget.back_btn.pressed.connect(self._back_role_list)
+        self.roles_widget.role_list_widget.itemDoubleClicked.connect(self._switch_to_interactions_list)
+        self.roles_widget.back_btn.pressed.connect(self._switch_to_master_chooser)
         self.roles_widget.refresh_btn.pressed.connect(self._refresh_role_list)
         # interactions list widget
         self.interactions_widget.interactions_list_widget.setIconSize(QSize(50, 50))
         self.interactions_widget.interactions_list_widget.itemDoubleClicked.connect(self._start_interaction)
-        self.interactions_widget.back_btn.pressed.connect(self._uninit_interactions_list)
-        self.interactions_widget.interactions_list_widget.itemClicked.connect(self._select_app_list)  # rocon master item click event
+        self.interactions_widget.back_btn.pressed.connect(self._switch_to_role_list)
+        self.interactions_widget.interactions_list_widget.itemClicked.connect(self._display_interaction_info)  # rocon master item click event
         self.interactions_widget.stop_interactions_button.pressed.connect(self._stop_interaction)
         self.interactions_widget.stop_interactions_button.setDisabled(True)
 
@@ -87,11 +86,12 @@ class QInteractionsChooser(QMainWindow):
         self._init()
 
     def _init(self):
-        (result, message) = self._init_role_list()
+        (result, message) = self.interactive_client._connect(self.rocon_master_name, self.rocon_master_uri, self.host_name)
         if not result:
             QMessageBox.warning(self, 'Connection Failed', "%s." % message.capitalize(), QMessageBox.Ok)
-            self._back_role_list()
+            self._switch_to_master_chooser()
             return
+        self._refresh_role_list()
         # Ugly Hack : our window manager is not graying out the button when an interaction closes itself down and the appropriate
         # callback (_set_stop_interactions_button) is fired. It does otherwise though so it looks like the window manager
         # is getting confused when the original program doesn't have the focus.
@@ -99,45 +99,32 @@ class QInteractionsChooser(QMainWindow):
         # Taking control of it ourselves works...
         self.interactions_widget.stop_interactions_button.setStyleSheet("QPushButton:disabled { color: gray }")
         self.roles_widget.show()
-        self.initialised = True
 
     ######################################
     # Roles List Widget
     ######################################
 
-    def _init_role_list(self):
-        (result, message) = self.interactive_client._connect(self.rocon_master_name, self.rocon_master_uri, self.host_name)
-        if not result:
-            return (False, message)
-        self._refresh_role_list()
-        return (True, "success")
-
-    def _uninit_role_list(self):
-
-        self.interactive_client.shutdown()
-        self.cur_selected_role = 0
-
-    def _select_role_list(self, Item):
-
+    def _switch_to_interactions_list(self, Item):
+        """
+        Take the selected role and switch to an interactions view of that role.
+        """
+        console.logdebug("Interactions Chooser : switching to the interactions list")
         self.cur_selected_role = str(Item.text())
-
-        self.interactive_client._select_role(self.cur_selected_role)
-
+        self.interactive_client.select_role(self.cur_selected_role)
         self.interactions_widget.show()
         self.interactions_widget.move(self.roles_widget.pos())
         self.roles_widget.hide()
-        self._init_interactions_list()
+        self._refresh_interactions_list()
 
-    def _back_role_list(self):
-        self._uninit_role_list()
-        self.initialised = False
+    def _switch_to_master_chooser(self):
+        console.logdebug("Interactions Chooser : switching back to the master chooser")
+        self.interactive_client.shutdown()
+        self.cur_selected_role = 0
         os.execv(QMasterChooser.rocon_remocon_script, ['', self.host_name])
 
     def _refresh_role_list(self):
         self.roles_widget.role_list_widget.clear()
-
         role_list = self.interactive_client.get_role_list()
-
         #set list widget item (reverse order because we push them on the top)
         for role in reversed(role_list):
             self.roles_widget.role_list_widget.insertItem(0, role)
@@ -150,36 +137,40 @@ class QInteractionsChooser(QMainWindow):
     # Interactions List Widget
     ######################################
 
-    def _init_interactions_list(self):
-        self._refresh_interactions_list()
-
-    def _uninit_interactions_list(self):
+    def _switch_to_role_list(self):
+        console.logdebug("Interactions Chooser : switching to the role list")
         self.roles_widget.show()
         self.roles_widget.move(self.interactions_widget.pos())
+        # reset this button for the next viewing
+        self.interactions_widget.stop_interactions_button.setEnabled(False)
         self.interactions_widget.hide()
 
-    def _select_app_list(self, Item):
+    def _display_interaction_info(self, Item):
+        """
+        Display the currently selected interaction's information. Triggered
+        when single-clicking on it in the interactions list view.
+        """
         list_widget = Item.listWidget()
         cur_index = list_widget.count() - list_widget.currentRow() - 1
         for k in self.interactions.values():
-            if(k['index'] == cur_index):
+            if(k.index == cur_index):
                 self.cur_selected_interaction = k
                 break
         self.interactions_widget.app_info.clear()
         info_text = "<html>"
         info_text += "<p>-------------------------------------------</p>"
-        web_interaction = web_interactions.parse(self.cur_selected_interaction['name'])
-        name = self.cur_selected_interaction['name'] if web_interaction is None else web_interaction.url
+        web_interaction = web_interactions.parse(self.cur_selected_interaction.name)
+        name = self.cur_selected_interaction.name if web_interaction is None else web_interaction.url
         info_text += "<p><b>name: </b>" + name + "</p>"
         info_text += "<p><b>  ---------------------</b>" + "</p>"
-        info_text += "<p><b>compatibility: </b>" + self.cur_selected_interaction['compatibility'] + "</p>"
-        info_text += "<p><b>display name: </b>" + self.cur_selected_interaction['display_name'] + "</p>"
-        info_text += "<p><b>description: </b>" + self.cur_selected_interaction['description'] + "</p>"
-        info_text += "<p><b>namespace: </b>" + self.cur_selected_interaction['namespace'] + "</p>"
-        info_text += "<p><b>max: </b>" + str(self.cur_selected_interaction['max']) + "</p>"
+        info_text += "<p><b>compatibility: </b>" + self.cur_selected_interaction.compatibility + "</p>"
+        info_text += "<p><b>display name: </b>" + self.cur_selected_interaction.display_name + "</p>"
+        info_text += "<p><b>description: </b>" + self.cur_selected_interaction.description + "</p>"
+        info_text += "<p><b>namespace: </b>" + self.cur_selected_interaction.namespace + "</p>"
+        info_text += "<p><b>max: </b>" + str(self.cur_selected_interaction.max) + "</p>"
         info_text += "<p><b>  ---------------------</b>" + "</p>"
-        info_text += "<p><b>remappings: </b>" + str(self.cur_selected_interaction['remappings']) + "</p>"
-        info_text += "<p><b>parameters: </b>" + str(self.cur_selected_interaction['parameters']) + "</p>"
+        info_text += "<p><b>remappings: </b>" + str(self.cur_selected_interaction.remappings) + "</p>"
+        info_text += "<p><b>parameters: </b>" + str(self.cur_selected_interaction.parameters) + "</p>"
         info_text += "</html>"
 
         self.interactions_widget.app_info.appendHtml(info_text)
@@ -207,23 +198,24 @@ class QInteractionsChooser(QMainWindow):
 
     def _refresh_interactions_list(self):
         """
-        This just does a complete redraw of the interactions list with the current state.
-        It's a bit brute force doing this every time the interactions' 'state' changes,
-        but this suffices for now.
-        """
-        self.interactions = {}
-        self.interactions = self.interactive_client.interactions
-        self.interactions_widget.interactions_list_widget.clear()
+        This just does a complete redraw of the interactions with the
+        currently selected role. It's a bit brute force doing this
+        every time the interactions' 'state' changes, but this suffices for now.
 
+        :param str role_name: role to request list of interactions for.
+        """
+        console.logdebug("Interactions Chooser : refreshing the interactions list")
+        self.interactions = self.interactive_client.interactions(self.cur_selected_role)
+        self.interactions_widget.interactions_list_widget.clear()
         index = 0
         for interaction in self.interactions.values():
-            interaction['index'] = index
+            interaction.index = index
             index = index + 1
 
-            self.interactions_widget.interactions_list_widget.insertItem(0, interaction['display_name'])
+            self.interactions_widget.interactions_list_widget.insertItem(0, interaction.display_name)
 
             # is it a currently running pairing
-            if self.interactive_client.pairing == interaction['hash']:
+            if self.interactive_client.pairing == interaction.hash:
                 self.interactions_widget.interactions_list_widget.item(0).setBackground(QColor(100, 100, 150))
 
             #setting the list font
@@ -232,12 +224,12 @@ class QInteractionsChooser(QMainWindow):
             self.interactions_widget.interactions_list_widget.item(0).setFont(font)
 
             #setting the icon
-            app_icon = interaction['icon']
-            if app_icon == "unknown.png":
+            icon = interaction.icon
+            if icon == "unknown.png":
                 icon = QIcon(self.icon_paths['unknown'])
                 self.interactions_widget.interactions_list_widget.item(0).setIcon(icon)
-            elif len(app_icon):
-                icon = QIcon(os.path.join(utils.get_icon_cache_home(), app_icon))
+            elif len(icon):
+                icon = QIcon(os.path.join(utils.get_icon_cache_home(), icon))
                 self.interactions_widget.interactions_list_widget.item(0).setIcon(icon)
             else:
                 console.logdebug("%s : No icon" % str(self.rocon_master_name))
@@ -248,40 +240,40 @@ class QInteractionsChooser(QMainWindow):
           selected interaction has any currently launched processes,
         '''
         if not self.interactions:
+            console.logwarn("No interactions")
             return
-        try:
-            if self.cur_selected_interaction["launch_list"]:
-                console.logdebug("Remocon : enabling stop interactions button [%s]" % self.cur_selected_interaction['display_name'])
-                self.interactions_widget.stop_interactions_button.setDisabled(False)
-            else:
-                console.logdebug("Remocon : disabling stop interactions button [%s]" % self.cur_selected_interaction['display_name'])
-                self.interactions_widget.stop_interactions_button.setEnabled(False)
-        except KeyError:
-            pass  # do nothing
+        console.logwarn("Launch list: %s" % self.cur_selected_interaction.launch_list)
+        if self.cur_selected_interaction.launch_list:
+            console.logdebug("Interactions Chooser : enabling stop interactions button [%s]" % self.cur_selected_interaction.display_name)
+            self.interactions_widget.stop_interactions_button.setEnabled(True)
+        else:
+            console.logdebug("Interactions Chooser : disabling stop interactions button [%s]" % self.cur_selected_interaction.display_name)
+            self.interactions_widget.stop_interactions_button.setEnabled(False)
 
     ######################################
     # Start/Stop Interactions
     ######################################
 
     def _start_interaction(self):
-        console.logdebug("Remocon : starting interaction [%s]" % str(self.cur_selected_interaction['name']))
-        (result, message) = self.interactive_client.start_interaction(self.cur_selected_interaction['hash'])
+        console.logdebug("Interactions Chooser : starting interaction [%s]" % str(self.cur_selected_interaction.name))
+        (result, message) = self.interactive_client.start_interaction(self.cur_selected_role,
+                                                                      self.cur_selected_interaction.hash)
         if result:
-            if self.cur_selected_interaction['pairing']:
+            if self.cur_selected_interaction.is_paired_type():
                 self._refresh_interactions_list()  # make sure the highlight is working
             self.interactions_widget.stop_interactions_button.setDisabled(False)
         else:
             QMessageBox.warning(self, 'Start Interaction Failed', "%s." % message.capitalize(), QMessageBox.Ok)
-            console.logwarn("Remocon : start interaction failed [%s]" % message)
+            console.logwarn("Interactions Chooser : start interaction failed [%s]" % message)
 
     def _stop_interaction(self):
-        console.logdebug("Remocon : stopping interaction %s " % str(self.cur_selected_interaction['name']))
-        (result, message) = self.interactive_client.stop_interaction(self.cur_selected_interaction['hash'])
+        console.logdebug("Interactions Chooser : stopping interaction %s " % str(self.cur_selected_interaction.name))
+        (result, message) = self.interactive_client.stop_interaction(self.cur_selected_interaction.hash)
         if result:
-            if self.cur_selected_interaction['pairing']:
+            if self.cur_selected_interaction.is_paired_type():
                 self._refresh_interactions_list()  # make sure the highlight is disabled
             self._set_stop_interactions_button()
             #self.interactions_widget.stop_interactions_button.setDisabled(True)
         else:
             QMessageBox.warning(self, 'Stop Interaction Failed', "%s." % message.capitalize(), QMessageBox.Ok)
-            console.logwarn("Remocon : stop interaction failed [%s]" % message)
+            console.logwarn("Interactions Chooser : stop interaction failed [%s]" % message)

--- a/rocon_remocon/src/rocon_remocon/interactions_table.py
+++ b/rocon_remocon/src/rocon_remocon/interactions_table.py
@@ -1,0 +1,126 @@
+#
+# License: BSD
+#   https://raw.github.com/robotics-in-concert/rocon_qt_gui/license/LICENSE
+#
+##############################################################################
+# Description
+##############################################################################
+
+"""
+.. module:: interactions_table
+   :platform: Unix
+   :synopsis: A database of interactions.
+
+
+This module provides a class that acts as a database (dictionary style) of
+some set of interactions.
+
+----
+
+"""
+##############################################################################
+# Imports
+##############################################################################
+
+import rocon_console.console as console
+import rocon_uri
+
+from rocon_interactions import InvalidInteraction
+
+##############################################################################
+# Classes
+##############################################################################
+
+
+class InteractionsTable(object):
+    '''
+      The runtime populated interactions table along with methods to
+      manipulate it.
+
+      .. include:: weblinks.rst
+    '''
+    __slots__ = [
+        'interactions',  # rocon_interactions.interactions.Interaction[]
+    ]
+
+    def __init__(self, filter_pairing_interactions=False):
+        """
+        Constructs an empty interactions table.
+
+        :param bool filter_pairing_interactions: do not load any paired interactions
+        """
+        self.interactions = []
+        """List of :class:`.Interaction` objects that will form the elements of the table."""
+
+    def roles(self):
+        '''
+          List all roles for the currently stored interactions.
+
+          :returns: a list of all roles
+          :rtype: str[]
+        '''
+        # uniquify the list
+        return list(set([i.role for i in self.interactions]))
+
+    def __len__(self):
+        return len(self.interactions)
+
+    def __str__(self):
+        """
+        Convenient string representation of the table.
+        """
+        s = ''
+        for interaction in self.interactions:
+            s += "\n".join("  " + i for i in str(interaction).splitlines()) + '\n'
+        return s
+
+    def generate_role_view(self, role_name):
+        '''
+        Creates a temporary copy of interactions filtered by the specified role
+        and sorts them into a dictionary view keyed by hash. This is a convenient
+        object for use by the interactions chooser.
+
+        :param str role_name: the filter for retrieving interactions
+
+        :returns: A role based view of the interactions
+        :rtype: dict { hash : :class:`.interactions.Interaction` }
+        '''
+        # there's got to be a faster way of doing this.
+        role_view = {}
+        for interaction in self.interactions:
+            if interaction.role == role_name:
+                role_view[interaction.hash] = interaction
+        return role_view
+
+    def clear(self, role_name):
+        """
+        Clear all interactions belonging to this role.
+
+        :param str role_name:
+        """
+        self.interactions[:] = [i for i in self.interactions if i.role != role_name]
+
+    def append(self, interaction):
+        """
+        Append an interaction to the table.
+
+        :param :class:`.Interaction` interaction:
+        """
+        matches = [i for i in self.interactions if i.hash == interaction.hash]
+        if not matches:
+            self.interactions.append(interaction)
+        else:
+            console.logwarn("Interactions Table : tried to append an already existing interaction [%s]" % interaction.hash)
+
+    def find(self, interaction_hash):
+        '''
+        Find the specified interaction.
+
+        :param str interaction_hash: in crc32 format
+
+        :returns: interaction if found, None otherwise.
+        :rtype: :class:`.Interaction` or None
+        '''
+        interaction = next((interaction for interaction in self.interactions
+                            if interaction.hash == interaction_hash), None)
+        return interaction

--- a/rocon_remocon/src/rocon_remocon/interactive_client.py
+++ b/rocon_remocon/src/rocon_remocon/interactive_client.py
@@ -33,6 +33,8 @@ import rocon_interactions
 
 from . import utils
 from .launch import LaunchInfo
+from .interactions import Interaction
+from .interactions_table import InteractionsTable
 
 ##############################################################################
 # InteractiveClient
@@ -46,8 +48,8 @@ class InteractiveClient():
           @param stop_app_postexec_fn : callback to fire when a listener detects an app getting stopped.
           @type method with no args
         '''
+        self._interactions_table = InteractionsTable()
         self._stop_interaction_postexec_fn = stop_interaction_postexec_fn
-        self.interactions = {}
         self.is_connect = False
         self.key = uuid.uuid4()
 
@@ -63,8 +65,12 @@ class InteractiveClient():
                                                        uri=str(self.rocon_uri),
                                                        icon=rocon_std_msgs.Icon()
                                                        )
-        console.logdebug("InteractiveClient : initialised")
+        console.logdebug("Interactive Client : initialised")
         self.pairing = None  # if an interaction is currently pairing, this will store its hash
+
+        # expose underlying functionality higher up
+        self.interactions = self._interactions_table.generate_role_view
+        """Get a dictionary of interactions belonging to the specified role."""
 
     def _connect(self, rocon_master_name="", ros_master_uri="http://localhost:11311", host_name='localhost'):
 
@@ -72,10 +78,10 @@ class InteractiveClient():
         os.environ["ROS_MASTER_URI"] = ros_master_uri
         os.environ["ROS_HOSTNAME"] = host_name
 
-        console.logdebug("InteractiveClient : Connection Details")
-        console.logdebug("InteractiveClient :   Node Name: " + self.name)
-        console.logdebug("InteractiveClient :   ROS_MASTER_URI: " + ros_master_uri)
-        console.logdebug("InteractiveClient :   ROS_HOSTNAME: " + host_name)
+        console.logdebug("Interactive Client : Connection Details")
+        console.logdebug("Interactive Client :   Node Name: " + self.name)
+        console.logdebug("Interactive Client :   ROS_MASTER_URI: " + ros_master_uri)
+        console.logdebug("Interactive Client :   ROS_HOSTNAME: " + host_name)
 
         # Need to make sure we give init a unique node name and we need a unique uuid
         # for the remocon-role manager interaction anyway:
@@ -92,46 +98,38 @@ class InteractiveClient():
         self.get_interactions_service_proxy = rospy.ServiceProxy(get_interactions_service_name, rocon_interaction_srvs.GetInteractions)
         self.get_roles_service_proxy = rospy.ServiceProxy(get_roles_service_name, rocon_interaction_srvs.GetRoles)
         self.request_interaction_service_proxy = rospy.ServiceProxy(request_interaction_service_name, rocon_interaction_srvs.RequestInteraction)
-        self.remocon_status_pub = rospy.Publisher("remocons/" + self.name, rocon_interaction_msgs.RemoconStatus, latch=True)
+        self.remocon_status_pub = rospy.Publisher("remocons/" + self.name, rocon_interaction_msgs.RemoconStatus, latch=True, queue_size=10)
 
         try:
             # if its available, should be quick to find this one since we found the others...
             pairing_topic_name = rocon_python_comms.find_topic('rocon_interaction_msgs/Pair', timeout=rospy.rostime.Duration(0.5), unique=True)
             self.pairing_status_subscriber = rospy.Subscriber(pairing_topic_name, rocon_interaction_msgs.Pair, self._subscribe_pairing_status_callback)
         except rocon_python_comms.NotFoundException as e:
-            console.logdebug("InteractiveClient : support for paired interactions disabled [not found]")
+            console.logdebug("Interactive Client : support for paired interactions disabled [not found]")
 
         self._publish_remocon_status()
         self.is_connect = True
         return (True, "success")
 
-    def _disconnect(self):
-        if(self.is_connect != True):
-            self.shutdown()
-
-    def _is_shutdown(self):
-        print "[remocon_info] shut down is complete"
-
     def shutdown(self):
+        console.logdebug("Interactive Client : shutdown")
         if(self.is_connect != True):
             return
         else:
-            console.logdebug("InteractiveClient : shutting down all rapps")
-            for app_hash in self.interactions.keys():
-                self.stop_interaction(app_hash)
+            console.logdebug("Interactive Client : shutting down all interactions")
+            for interaction in self._interactions_table.interactions:
+                self.stop_interaction(interaction.hash)
 
-            self.interactions = {}
+            self._interactions_table = InteractionsTable()
             self.is_connect = False
 
             rospy.signal_shutdown("shut down remocon_info")
             while not rospy.is_shutdown():
                 rospy.rostime.wallsleep(0.1)
 
-            self.is_connect = False
             self.remocon_status_pub.unregister()
-
             self.remocon_status_pub = None
-            console.logdebug("InteractiveClient : has shutdown.")
+            console.logdebug("Interactive Client : has shutdown.")
 
     def get_role_list(self):
         if not self.is_connect:
@@ -143,67 +141,49 @@ class InteractiveClient():
             return []
         return response.roles
 
-    def _select_role(self, role_name):
-        roles = []
-        roles.append(role_name)
-
-        call_result = self.get_interactions_service_proxy(roles, self.platform_info.uri)
-        console.logdebug("InteractiveClient : call result")
-        self.interactions = {}
-        for interaction in call_result.interactions:
-            if(interaction.role == role_name):
-                # TODO should create a class out of this mash, dicts of dicts are prone to mistakes and hard to introspect.
-                #if self.interactions.has_key(interaction.hash):
-                #    pass
-                #else:
-                #    self.interactions[interaction.hash]={}
-                #    self.interactions[interaction.hash]['launch_list'] ={}
-                self.interactions[interaction.hash] = {}
-                self.interactions[interaction.hash]['launch_list'] = {}
-
-                self.interactions[interaction.hash]['name'] = interaction.name
-                self.interactions[interaction.hash]['compatibility'] = interaction.compatibility
-                icon_name = interaction.icon.resource_name.split('/').pop()
-                if interaction.icon.data:
-                    icon = open(os.path.join(utils.get_icon_cache_home(), icon_name), 'w')
-                    icon.write(interaction.icon.data)
-                    icon.close()
-                self.interactions[interaction.hash]['icon'] = icon_name
-                self.interactions[interaction.hash]['display_name'] = interaction.display_name
-                self.interactions[interaction.hash]['description'] = interaction.description
-                self.interactions[interaction.hash]['namespace'] = interaction.namespace
-                self.interactions[interaction.hash]['max'] = interaction.max
-                self.interactions[interaction.hash]['remappings'] = interaction.remappings
-                self.interactions[interaction.hash]['parameters'] = interaction.parameters
-                self.interactions[interaction.hash]['hash'] = interaction.hash
-                self.interactions[interaction.hash]['pairing'] = interaction.pairing.rapp if interaction.pairing.rapp else None
-
-    def start_interaction(self, interaction_hash):
+    def select_role(self, role_name):
         """
+        Contact the interactions manager and retrieve all the interactions
+        associated to a particular role.
+
+        :param str role_name: role to request list of interactions for.
+        """
+        call_result = self.get_interactions_service_proxy([role_name], self.platform_info.uri)
+        for msg in call_result.interactions:
+            self._interactions_table.append(Interaction(msg))
+        # could use a whole bunch of exception checking here, removing
+        # self.interactions[role_name] if necessary.
+
+    def start_interaction(self, role_name, interaction_hash):
+        """
+        :param str interaction_hash: the key
+        :param str role_name: help refine the search by specifying what role this interaction is for
+
         :returns: result of the effort to start an interaction, with a message if there was an error.
         :rtype: (bool, message)
         """
-        if not interaction_hash in self.interactions.keys():
+        interaction = self._interactions_table.find(interaction_hash)
+        if interaction is None:
             return (False, "interaction key %s not found in interactions table" % interaction_hash)
-        interaction = self.interactions[interaction_hash]
-        if self.pairing and interaction['pairing']:
-            paired_interaction_display_name = self.interactions[self.pairing]['display_name']
-            return (False, "remocon already pairing (%s,%s) and additional pairing is not permitted " % (interaction['pairing'], paired_interaction_display_name))
+        if interaction.role != role_name:
+            return (False, "interaction key %s is in the interactions table, but under another role" % interaction_hash)
+        if self.pairing and interaction.is_paired_type():
+            return (False, "remocon already pairing (%s,%s) and additional pairing is not permitted " % (interaction.pairing.rapp, interaction.display_name))
 
         #get the permission
-        call_result = self.request_interaction_service_proxy(remocon=self.name, hash=interaction['hash'])
+        call_result = self.request_interaction_service_proxy(remocon=self.name, hash=interaction.hash)
 
         if call_result.error_code == ErrorCodes.SUCCESS:
-            console.logdebug("InteractiveClient : interaction request granted")
+            console.logdebug("Interactive Client : interaction request granted")
             try:
-                (app_executable, start_app_handler) = self._determine_interaction_type(interaction['name'])
+                (app_executable, start_app_handler) = self._determine_interaction_type(interaction.name)
             except rocon_interactions.InvalidInteraction as e:
                 return False, ("invalid interaction specified [%s]" % str(e))
             result = start_app_handler(interaction, app_executable)
             if result:
                 self._publish_remocon_status()
-                if interaction['pairing']:
-                    self.pairing = interaction['hash']
+                if interaction.is_paired_type():
+                    self.pairing = interaction.hash
                 return (result, "success")
             else:
                 return (result, "unknown")
@@ -224,12 +204,12 @@ class InteractiveClient():
         '''
         # pairing trigger (i.e. dummy interaction)
         if not interaction_name:
-            console.logdebug("InteractiveClient : start a dummy interaction for triggering a pair")
+            console.logdebug("Interactive Client : start a dummy interaction for triggering a pair")
             return ('', self._start_dummy_interaction)
         # roslaunch
         try:
             launcher_filename = rocon_python_utils.ros.find_resource_from_string(interaction_name, extension='launch')
-            console.logdebug("InteractiveClient : regular start app [%s]" % interaction_name)
+            console.logdebug("Interactive Client : regular start app [%s]" % interaction_name)
             return (launcher_filename, self._start_roslaunch_interaction)
         except (rospkg.ResourceNotFound, ValueError):
             unused_filename, extension = os.path.splitext(interaction_name)
@@ -240,7 +220,7 @@ class InteractiveClient():
         # rosrun
         try:
             rosrunnable_filename = rocon_python_utils.ros.find_resource_from_string(interaction_name)
-            console.logdebug("InteractiveClient : start_app_rosrunnable [%s]" % interaction_name)
+            console.logdebug("Interactive Client : start_app_rosrunnable [%s]" % interaction_name)
             return (rosrunnable_filename, self._start_rosrunnable_interaction)
         except rospkg.ResourceNotFound:
             pass
@@ -250,36 +230,36 @@ class InteractiveClient():
         web_interaction = web_interactions.parse(interaction_name)
         if web_interaction is not None:
             if web_interaction.is_web_url():
-                console.logdebug("InteractiveClient : _start_weburl_interaction [%s]" % web_interaction.url)
+                console.logdebug("Interactive Client : _start_weburl_interaction [%s]" % web_interaction.url)
                 return (web_interaction.url, self._start_weburl_interaction)
             elif web_interaction.is_web_app():
-                console.logdebug("InteractiveClient : _start_webapp_interaction [%s]" % web_interaction.url)
+                console.logdebug("Interactive Client : _start_webapp_interaction [%s]" % web_interaction.url)
                 return (web_interaction.url, self._start_webapp_interaction)
         # executable
         if rocon_python_utils.system.which(interaction_name) is not None:
-            console.logdebug("InteractiveClient : _start_global_executable_interaction [%s]")
+            console.logdebug("Interactive Client : _start_global_executable_interaction [%s]")
             return (interaction_name, self._start_global_executable_interaction)
         else:
             raise rocon_interactions.InvalidInteraction("could not find a valid rosrunnable or global executable for '%s' (mispelt, not installed?)" % interaction_name)
 
     def _start_dummy_interaction(self, interaction, unused_filename):
         console.loginfo("InteractiveClient : starting paired dummy interaction")
-        anonymous_name = interaction['name'] + "_" + uuid.uuid4().hex
+        anonymous_name = interaction.name + "_" + uuid.uuid4().hex
         #process_listener = partial(self._process_listeners, anonymous_name, 1)
         #process = rocon_python_utils.system.Popen([rosrunnable_filename], postexec_fn=process_listener)
-        interaction['launch_list'][anonymous_name] = LaunchInfo(anonymous_name, True, None, lambda: None)  # empty shutdown function
+        interaction.launch_list[anonymous_name] = LaunchInfo(anonymous_name, True, None, lambda: None)  # empty shutdown function
         return True
 
     def _start_roslaunch_interaction(self, interaction, roslaunch_filename):
         '''
           Start a ros launchable application, applying parameters and remappings if specified.
         '''
-        name_space = '/service/' + interaction['namespace']
+        name_space = '/service/' + interaction.namespace
         temp = tempfile.NamedTemporaryFile(mode='w+t', delete=False)
         #add parameters
         launch_text  = '<launch>\n'  #@IgnorePep8 noqa
         launch_text += '    <group ns="%s">\n' % (name_space)
-        launch_text += '        <rosparam>%s</rosparam>\n' % (interaction['parameters'])
+        launch_text += '        <rosparam>%s</rosparam>\n' % (interaction.parameters)
         launch_text += '        <include file="%s"/>\n' % (roslaunch_filename)
         launch_text += '    </group>\n'
         launch_text += '</launch>\n'
@@ -294,17 +274,17 @@ class InteractiveClient():
                                                             process_listeners=[self.listener])
             _launch._load_config()
             for N in _launch.config.nodes:
-                for k in interaction['remappings']:
+                for k in interaction.remappings:
                     N.remap_args.append([(name_space + '/' + k.remap_from).replace('//', '/'), k.remap_to])
             _launch.start()
 
             process_name = str(_launch.pm.get_process_names_with_spawn_count()[0][0][0])
-            interaction['launch_list'][process_name] = LaunchInfo(process_name, True, _launch, _launch.shutdown)
+            interaction.launch_list[process_name] = LaunchInfo(process_name, True, _launch, _launch.shutdown)
             return True
         except Exception, inst:
             print inst
-            interaction['running'] = str(False)
-            print "Fail to launch: %s" % (interaction['name'])
+            interaction.running = str(False)
+            print "Fail to launch: %s" % (interaction.name)
             return False
 
     def _start_rosrunnable_interaction(self, interaction, rosrunnable_filename):
@@ -314,25 +294,29 @@ class InteractiveClient():
         '''
         # the following is guaranteed since we came back from find_resource calls earlier
         # note we're overriding the rosrunnable filename here - rosrun doesn't actually take the full path.
-        package_name, rosrunnable_filename = interaction['name'].split('/')
+        console.logwarn("Interactive Client : starting rosrunnable [%s]" % interaction.name)
+        package_name, rosrunnable_filename = interaction.name.split('/')
         name = os.path.basename(rosrunnable_filename).replace('.', '_')
         anonymous_name = name + "_" + uuid.uuid4().hex
         process_listener = partial(self._process_listeners, anonymous_name, 1)
         command_args = ['rosrun', package_name, rosrunnable_filename, '__name:=%s' % anonymous_name]
         remapping_args = []
-        for remap in interaction['remappings']:
+        for remap in interaction.remappings:
             remapping_args.append(remap.remap_from + ":=" + remap.remap_to)
         command_args.extend(remapping_args)
         process = rocon_python_utils.system.Popen(command_args, postexec_fn=process_listener)
-        interaction['launch_list'][anonymous_name] = LaunchInfo(anonymous_name, True, process, partial(process.send_signal, signal.SIGINT))
+        interaction.launch_list[anonymous_name] = LaunchInfo(anonymous_name, True, process, partial(process.send_signal, signal.SIGINT))
         return True
 
     def _start_global_executable_interaction(self, interaction, filename):
+        console.logwarn("Interactive Client : starting global executable [%s]" % interaction.name)
         name = os.path.basename(filename).replace('.', '_')
         anonymous_name = name + "_" + uuid.uuid4().hex
         process_listener = partial(self._process_listeners, anonymous_name, 1)
         process = rocon_python_utils.system.Popen([filename], postexec_fn=process_listener)
-        interaction['launch_list'][anonymous_name] = LaunchInfo(anonymous_name, True, process, partial(process.send_signal, signal.SIGINT))
+        interaction.launch_list[anonymous_name] = LaunchInfo(anonymous_name, True, process, partial(process.send_signal, signal.SIGINT))
+        print("Interaction \n%s" % interaction)
+        print("Interaction Table \n%s" % self._interactions_table)
         return True
 
     def _start_weburl_interaction(self, interaction, url):
@@ -345,7 +329,7 @@ class InteractiveClient():
             anonymous_name = name + "_" + uuid.uuid4().hex
             process_listener = partial(self._process_listeners, anonymous_name, 1)
             process = rocon_python_utils.system.Popen([web_browser, "--new-window", url], postexec_fn=process_listener)
-            interaction['launch_list'][anonymous_name] = LaunchInfo(anonymous_name, True, process, partial(process.send_signal, signal.SIGINT))
+            interaction.launch_list[anonymous_name] = LaunchInfo(anonymous_name, True, process, partial(process.send_signal, signal.SIGINT))
             return True
         else:
             return False
@@ -364,7 +348,7 @@ class InteractiveClient():
             anonymous_name = name + "_" + uuid.uuid4().hex
             process_listener = partial(self._process_listeners, anonymous_name, 1)
             process = rocon_python_utils.system.Popen([web_browser, "--new-window", url], postexec_fn=process_listener)
-            interaction['launch_list'][anonymous_name] = LaunchInfo(anonymous_name, True, process, partial(process.send_signal, signal.SIGINT))
+            interaction.launch_list[anonymous_name] = LaunchInfo(anonymous_name, True, process, partial(process.send_signal, signal.SIGINT))
             return True
         else:
             return False
@@ -373,28 +357,28 @@ class InteractiveClient():
         """
         This stops all launches for an interaction of a particular type.
         """
-        if not interaction_hash in self.interactions:
+        interaction = self._interactions_table.find(interaction_hash)
+        if interaction is None:
+            console.logwarn("Interactive Client : interaction key %s not found in interactions table" % interaction_hash)
             return (False, "interaction key %s not found in interactions table" % interaction_hash)
-        interaction = self.interactions[interaction_hash]
-        #print("InteractiveClient : Launched App List- %s" % str(interaction["launch_list"]))
         try:
-            for launch_info in interaction["launch_list"].values():
+            for launch_info in interaction.launch_list.values():
                 if launch_info.running:
                     launch_info.shutdown()
-                    del self.interactions[interaction_hash]["launch_list"][launch_info.name]
-                    print "InteractiveClient : %s APP STOP" % (launch_info.name)
+                    del interaction.launch_list[launch_info.name]
+                    console.loginfo("Interactive Client : interaction stopped [%s]" % (launch_info.name))
                 elif launch_info.process == None:
                     launch_info.running = False
-                    del self.interactions[interaction_hash]["launch_list"][launch_info.name]
-                    print "InteractiveClient : %s APP LAUNCH IS NONE" % (launch_info.name)
+                    del interaction.launch_list.launch_list[launch_info.name]
+                    console.loginfo("Interactive Client : no attached interaction process to stop [%s]" % (launch_info.name))
                 else:
-                    del self.interactions[interaction_hash]["launch_list"][launch_info.name]
-                    print "InteractiveClient : %s APP IS ALREADY STOP" % (launch_info.name)
+                    del interaction.launch_list.launch_list[launch_info.name]
+                    console.loginfo("Interactive Client : interaction is already stopped [%s]" % (launch_info.name))
         except Exception as e:
             # this is bad...should not create bottomless exception buckets.
             return (False, "unknown failure - (%s)(%s)" % (type(e), str(e)))
-        print "InteractiveClient : updated app list- %s" % str(self.interactions[interaction_hash]["launch_list"])
-        if interaction['pairing']:
+        console.logdebug("Interactive Client : interaction's updated launch list- %s" % str(interaction.launch_list))
+        if interaction.is_paired_type():
             self.pairing = None
         self._publish_remocon_status()
         return (True, "success")
@@ -409,14 +393,15 @@ class InteractiveClient():
           @param exit_code : could be utilised from roslaunched processes but not currently used.
           @type int
         '''
-        for interaction in self.interactions.values():
-            if name in interaction['launch_list']:
-                del interaction['launch_list'][name]
+        console.logdebug("Interactive Client : process_listener called by terminating interaction [%s]" % name)
+        for interaction in self._interactions_table.interactions:
+            if name in interaction.launch_list:
+                del interaction.launch_list[name]
                 # toggle the pairing indicator if it was a pairing interaction
-                if interaction['pairing']:
+                if interaction.is_paired_type():
                     self.pairing = None
-                if not interaction['launch_list']:
-                    console.logdebug("InteractiveClient : process_listener caught terminating interaction [%s]" % name)
+                if not interaction.launch_list:
+                    console.logwarn("Interactive Client : process_listener caught terminating interaction [%s]" % name)
                     # inform the gui to update if necessary
                     self._stop_interaction_postexec_fn()
                     # update the rocon interactions handler
@@ -432,18 +417,18 @@ class InteractiveClient():
         remocon_status.uuid = str(self.key.hex)
         remocon_status.version = rocon_std_msgs.Strings.ROCON_VERSION
         running_interactions = []
-        for interaction_hash in self.interactions.keys():
-            for unused_process_name in self.interactions[interaction_hash]["launch_list"].keys():
-                running_interactions.append(interaction_hash)
+        for interaction in self._interactions_table.interactions:
+            for unused_process_name in interaction.launch_list.keys():
+                running_interactions.append(interaction.hash)
         remocon_status.running_interactions = running_interactions
-        print "[remocon_info] publish remocon status"
+        console.logdebug("Interactive Client : publishing remocon status")
         self.remocon_status_pub.publish(remocon_status)
 
     def _subscribe_pairing_status_callback(self, msg):
-        console.logdebug("InteractiveClient : pairing status callback [%s][%s]" % (msg.rapp, msg.remocon))
+        console.logdebug("Interactive Client : pairing status callback [%s][%s]" % (msg.rapp, msg.remocon))
         if self.pairing:
             if not msg.rapp and msg.remocon == self.name:
-                console.logdebug("InteractiveClient : the rapp in this paired interaction terminated")
+                console.logdebug("Interactive Client : the rapp in this paired interaction terminated")
                 # there will only ever be one allowed instance of a paired interaction, so ok to call a stop to all instances of this interaction type
                 self.stop_interaction(self.pairing)
                 # updat the gui
@@ -461,12 +446,12 @@ class InteractiveClient():
            json strings as it makes it easier for web apps to handle them.
         """
         interaction_data = {}
-        interaction_data['display_name'] = interaction['display_name']
+        interaction_data['display_name'] = interaction.display_name
         # parameters
-        interaction_data['parameters'] = yaml.load(interaction['parameters'])
+        interaction_data['parameters'] = yaml.load(interaction.parameters)
         # remappings
-        interaction_data['remappings'] = {}  # need to create a dictionary for easy parsing (note: interaction['remappings'] is a list of rocon_std_msgs.Remapping)
-        for r in interaction['remappings']:
+        interaction_data['remappings'] = {}  # need to create a dictionary for easy parsing (note: interaction.remappings is a list of rocon_std_msgs.Remapping)
+        for r in interaction.remappings:
             interaction_data['remappings'][r.remap_from] = r.remap_to
         # package all the data in json format and dump it to one query string variable
         console.logdebug("Remocon Info : web app query string %s" % interaction_data)

--- a/rocon_remocon/src/rocon_remocon/interactive_client.py
+++ b/rocon_remocon/src/rocon_remocon/interactive_client.py
@@ -118,7 +118,6 @@ class InteractiveClient():
         return (True, "success")
 
     def shutdown(self):
-        console.logdebug("Interactive Client : shutdown")
         if(self.is_connect != True):
             return
         else:
@@ -297,7 +296,6 @@ class InteractiveClient():
         '''
         # the following is guaranteed since we came back from find_resource calls earlier
         # note we're overriding the rosrunnable filename here - rosrun doesn't actually take the full path.
-        console.logwarn("Interactive Client : starting rosrunnable [%s]" % interaction.name)
         package_name, rosrunnable_filename = interaction.name.split('/')
         name = os.path.basename(rosrunnable_filename).replace('.', '_')
         anonymous_name = name + "_" + uuid.uuid4().hex
@@ -380,7 +378,7 @@ class InteractiveClient():
         except Exception as e:
             # this is bad...should not create bottomless exception buckets.
             return (False, "unknown failure - (%s)(%s)" % (type(e), str(e)))
-        console.logdebug("Interactive Client : interaction's updated launch list- %s" % str(interaction.launch_list))
+        #console.logdebug("Interactive Client : interaction's updated launch list- %s" % str(interaction.launch_list))
         if interaction.is_paired_type():
             self.pairing = None
         self._publish_remocon_status()
@@ -396,7 +394,7 @@ class InteractiveClient():
           @param exit_code : could be utilised from roslaunched processes but not currently used.
           @type int
         '''
-        console.logdebug("Interactive Client : process_listener called by terminating interaction [%s]" % name)
+        console.logdebug("Interactive Client : process_listener detected terminating interaction [%s]" % name)
         for interaction in self._interactions_table.interactions:
             if name in interaction.launch_list:
                 del interaction.launch_list[name]
@@ -404,7 +402,7 @@ class InteractiveClient():
                 if interaction.is_paired_type():
                     self.pairing = None
                 if not interaction.launch_list:
-                    console.logwarn("Interactive Client : process_listener caught terminating interaction [%s]" % name)
+                    console.logwarn("Interactive Client : process_listener detected unknown terminating interaction [%s]" % name)
                     # inform the gui to update if necessary
                     self._stop_interaction_postexec_fn()
                     # update the rocon interactions handler

--- a/rocon_remocon/src/rocon_remocon/interactive_client.py
+++ b/rocon_remocon/src/rocon_remocon/interactive_client.py
@@ -43,6 +43,12 @@ from .interactions_table import InteractionsTable
 
 class InteractiveClient():
 
+    shutdown_timeout = 0.5
+    """
+    Time to wait before shutting down so remocon status updates can be received and processed
+    by the interactions manager (important for pairing interactions).
+    """
+
     def __init__(self, stop_interaction_postexec_fn):
         '''
           @param stop_app_postexec_fn : callback to fire when a listener detects an app getting stopped.
@@ -120,15 +126,12 @@ class InteractiveClient():
             for interaction in self._interactions_table.interactions:
                 self.stop_interaction(interaction.hash)
 
-            self._interactions_table = InteractionsTable()
-            self.is_connect = False
-
+            rospy.rostime.wallsleep(InteractiveClient.shutdown_timeout)
+            console.logdebug("Interactive Client : signaling shutdown.")
             rospy.signal_shutdown("shut down remocon_info")
             while not rospy.is_shutdown():
                 rospy.rostime.wallsleep(0.1)
 
-            self.remocon_status_pub.unregister()
-            self.remocon_status_pub = None
             console.logdebug("Interactive Client : has shutdown.")
 
     def get_role_list(self):


### PR DESCRIPTION
This fixes #26.
- Introduces two new classes, `InteractionsTable` and `Interactions`
- These store the state of interactions continuously until going back to the _master chooser_.
