### PR TITLE
Disable pairings where the require interactions flag is set

### DIFF
--- a/rocon_remocon/.pydevproject
+++ b/rocon_remocon/.pydevproject
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?eclipse-pydev version="1.0"?><pydev_project>
-<pydev_property name="org.python.pydev.PYTHON_PROJECT_INTERPRETER">python</pydev_property>
+<pydev_property name="org.python.pydev.PYTHON_PROJECT_INTERPRETER">Default</pydev_property>
 <pydev_property name="org.python.pydev.PYTHON_PROJECT_VERSION">python 2.7</pydev_property>
 <pydev_pathproperty name="org.python.pydev.PROJECT_SOURCE_PATH">
 <path>/${PROJECT_DIR_NAME}/src</path>

--- a/rocon_remocon/src/rocon_remocon/interactions_chooser.py
+++ b/rocon_remocon/src/rocon_remocon/interactions_chooser.py
@@ -95,7 +95,7 @@ class InteractionsChooserUI():
                 is_running = True
                 enabled = True
             elif active_pairing is None:
-                enabled = True
+                enabled = not p.requires_interaction
             item = icon.QModelIconItem(p, enabled=enabled, running=is_running)
             self.pairings_view_model.appendRow(item)
 
@@ -161,7 +161,7 @@ class InteractionsChooserUI():
             is_running = (active_pairing.name == pairing.name)
             is_enabled = is_running
         else:
-            is_enabled = True
+            is_enabled = not pairing.requires_interaction
             is_running = False
         self.selected_pairing = pairing
         self.dialog = PairingDialog(self.widget,

--- a/rocon_remocon/ui/interactions_chooser.ui
+++ b/rocon_remocon/ui/interactions_chooser.ui
@@ -87,7 +87,7 @@
      </property>
      <widget class="QGroupBox" name="groupBox">
       <property name="title">
-       <string>Pairings (Launch Configurations)</string>
+       <string>Robot Application Configurations</string>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
@@ -104,7 +104,7 @@
      </widget>
      <widget class="QGroupBox" name="groupBox_2">
       <property name="title">
-       <string>Interactions</string>
+       <string>Remote Interactions</string>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>


### PR DESCRIPTION
So that they can only be started from the interaction itself.
